### PR TITLE
Fix test breakage with pytest == 2.6.3

### DIFF
--- a/webhelpers2/tests/test_misc.py
+++ b/webhelpers2/tests/test_misc.py
@@ -76,9 +76,9 @@ class TestFormatException(object):
 
     def test_from_exc_info(self):
         try:
-            assert False, 'foo'
+            raise ValueError('foo')
         except:
-            assert format_exception() == 'AssertionError: foo'
+            assert format_exception() == 'ValueError: foo'
 
 
 class TestDeprecate(object):


### PR DESCRIPTION
The latest release of pytest breaks a test.

Pytest mangles the assert statements in test functions so that they
raise specialized assertion errors.  Starting with pytest 2.6.3, the
exception raised by::

```
assert False, 'foo'
```

stringifies to `"foo\nassert False"` (where before it stringified to
`"foo"`.)
