### PR TITLE
Use python 2.6 compatible format string

### DIFF
--- a/webhelpers2/html/tags.py
+++ b/webhelpers2/html/tags.py
@@ -1026,4 +1026,4 @@ def _repr(obj, *args):
     """Helper for ``.__repr__`` using attributes as positional args."""
     classname = obj.__class__.__name__
     args_str = ", ".join(repr(x) for x in args)
-    return "{}({})".format(classname, args_str)
+    return "{0}({1})".format(classname, args_str)


### PR DESCRIPTION
Here’s one more fix for python 2.6.
