### PR TITLE
Allow constructing OptGroups with options

### DIFF
--- a/webhelpers2/html/tags.py
+++ b/webhelpers2/html/tags.py
@@ -312,6 +312,19 @@ class _OptionsList(list):
         opt = Option(label, value)
         self.append(opt)
 
+    @staticmethod
+    def _coerce_to_option(opt):
+        parsed_types = (Option, OptGroup)
+        seq_types = (list, tuple)
+
+        if isinstance(opt, parsed_types):
+            return opt
+        elif isinstance(opt, seq_types):
+            raise TypeError(
+                "lists/tuples are no longer allowed as elements in the "
+                "'options' arg: {0!r}".format(opt))
+        else:
+            return Option(opt)
 
 class OptGroup(_OptionsList):
     """A group of options.
@@ -320,13 +333,21 @@ class OptGroup(_OptionsList):
     I can be an element in ``Options``.
     """
 
-    def __init__(self, label):
+    def __init__(self, label, options=None):
         """Construct an ``OptGroup``.
 
-        * **label**: The group's label.
+        **label**: The group's label.
+
+        **options**: An iterable of ``Option`` instances, and/or
+        strings. If you pass strings, they will be converted to simple
+        ``Option`` instances (i.e., the label will be the string, and
+        the value will be ``None``).
+
         """
 
         self.label = label
+        if options:
+            self.extend(map(self._coerce_to_option, options))
 
     def __repr__(self):
         classname = self.__class__.__name__
@@ -356,30 +377,19 @@ class Options(_OptionsList):
         if prompt:
             self.add_option(prompt, "")
         if options:
-            parsed_types = (Option, OptGroup)
-            seq_types = (list, tuple)
-            for opt in options:
-                if isinstance(opt, parsed_types):
-                    self.append(opt)
-                elif isinstance(opt, seq_types):
-                    msg = (
-                        "lists/tuples are no longer allowed as elements in "
-                        "the 'options' arg: {0!r}")
-                    raise TypeError(msg.format(opt))
-                else:
-                    self.add_option(opt)
+            self.extend(map(self._coerce_to_option, options))
 
     def __repr__(self):
         classname = self.__class__.__name__
         return "{0}({1!r})".format(classname, list(self))
 
-    def add_optgroup(self, label):
+    def add_optgroup(self, label, options=None):
         """Create an ``OptGroup``, append it, and return it.
 
         The return value is the ``OptGroup`` instance. Call its
         ``.add_option`` method to add options to the group.
         """
-        group = OptGroup(label)
+        group = OptGroup(label, options)
         self.append(group)
         return group
 

--- a/webhelpers2/tests/test_tags.py
+++ b/webhelpers2/tests/test_tags.py
@@ -434,6 +434,11 @@ class TestOptGroup(object):
             expected = expected.replace("u'", "'")
         assert repr(group) == expected
 
+    def test_init_options(self):
+        group = OptGroup("foo", ["bar"])
+        assert len(group) == 1
+        assert group[0].label == 'bar'
+
 
 class TestOptionsArg(HTMLTestCase):
     def test1(self):
@@ -480,6 +485,12 @@ class TestOptions(HTMLTestCase):
         if six.PY3:
             expected = expected.replace("u'", "'")
         assert repr(opts) == expected
+
+    def test_add_optgroup(self):
+        opts = Options()
+        opts.add_optgroup('Foo', ['bar'])
+        assert opts[0].label == 'Foo'
+        assert opts[0][0].label == 'bar'
 
 
 class TestThSortable(HTMLTestCase):


### PR DESCRIPTION
As discussed in mikeorr/WebHelpers2#19, this adds an (optional)
``options`` argument to the ``OptGroup`` constructor.