### PR TITLE
Allow strings and literals to work with c keyword

### DIFF
--- a/webhelpers2/html/builder.py
+++ b/webhelpers2/html/builder.py
@@ -198,6 +198,8 @@ class HTMLBuilder(object):
             assert not args, "The special 'c' keyword argument cannot be used "\
     "in conjunction with non-keyword arguments"
             args = kw.pop("c")
+            if not hasattr(args, '__iter__'):
+                args = tuple(args)
         closed = kw.pop("_closed", True)
         nl = kw.pop("_nl", False)
         boolean_attrs = kw.pop("_bool", None)


### PR DESCRIPTION
HTML.tag newline function broke if a string or literal was passed using
the c keyword variable.

Example:

``` python
>>> from webhelpers2.html.builder import HTML
>>> HTML.div(HTML.p(c="hello, world", _nl=True), _nl=True)
<<< literal(u'<div>\n<p>\nh\ne\nl\nl\no\n,\n \nw\no\nr\nl\nd\n</p>\n\n</div>\n')
```

The above example would appear to work if _nl=False. The error is introduced by chunks.extend(args)
A work around would be always passing c kwargs as a tuple.
