### PR TITLE
Add html5lib to be able to parse html5 spec elements table.

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -9,5 +9,6 @@ commands=py.test
 deps =
     pytest
     beautifulsoup4
+    html5lib
 commands =
     py.test webhelpers2/tests/check_html_spec.py

--- a/webhelpers2/tests/check_html_spec.py
+++ b/webhelpers2/tests/check_html_spec.py
@@ -90,7 +90,7 @@ def test_compose_attrs(html5_attribute_table):
 @pytest.fixture(scope='module')
 def html5_index():
     resp = urlopen(HTML51_INDEX)
-    return BeautifulSoup(resp, 'html.parser')
+    return BeautifulSoup(resp, 'html5lib')
 
 
 @pytest.fixture(scope='module')


### PR DESCRIPTION
I guess closing TR tags (and others) is optional in some cases (I just learned).

SEE: "Tag omission in text/html" at [the-tr-element](https://html.spec.whatwg.org/multipage/tables.html#the-tr-element)

The spec omits the `</tr>` tag and it breaks the `"html.parser"`.
```html5
<table><caption>List of elements</caption><thead><tr><th> Element
     <th> Description
     <th> Categories
     <th> Parents†
     <th> Children
     <th> Attributes
     <th> Interface
   <tbody>
```

The html.parser in bs4 doesn't seem to handle this case.  I think you need to use the `"html5lib"` parser for bs4 and then the errors make a lot more sense.

Although I'm not sure what would be the best way to reconcile the actual changes: removed void elements and added void elements, attribute changes, etc.

This changes the errors to something like this for me (example of the 1 in 3 errors):

```text
>       assert HTML.void_tags == html5_empty_tags | html4_empty_tags
E       AssertionError: assert {'area', 'bas... 'embed', ...} == {'area', 'bas... 'embed', ...}
E         Extra items in the left set:
E         'keygen'
E         'menuitem'
E         Extra items in the right set:
E         'template'
E         'iframe'
E         Use -v to get more diff

webhelpers2/tests/check_html_spec.py:53: AssertionError
```